### PR TITLE
fetcher: support local kernel patches

### DIFF
--- a/contest/remote/exec.py
+++ b/contest/remote/exec.py
@@ -25,6 +25,7 @@ base_path=/common/path
 json_path=base-relative/path/to/json
 results_path=base-relative/path/to/raw/outputs
 tree_path=/root-path/to/kernel/git
+patches_path=/root-path/to/patches/dir
 [www]
 url=https://url-to-reach-base-path
 """
@@ -86,6 +87,7 @@ def main() -> None:
                 branches_url=config.get('remote', 'branches'),
                 results_path=os.path.join(base_dir, config.get('local', 'json_path')),
                 url_path=config.get('www', 'url') + '/' + config.get('local', 'json_path'),
+                patches_path=config.get('local', 'patches_path'),
                 tree_path=config.get('local', 'tree_path'))
     f.run()
 

--- a/contest/remote/kunit.py
+++ b/contest/remote/kunit.py
@@ -25,6 +25,7 @@ base_path=/common/path
 json_path=base-relative/path/to/json
 results_path=base-relative/path/to/raw/outputs
 tree_path=/root-path/to/kernel/git
+patches_path=/root-path/to/patches/dir
 [www]
 url=https://url-to-reach-base-path
 
@@ -170,6 +171,7 @@ def main() -> None:
                 results_path=os.path.join(base_dir, config.get('local', 'json_path')),
                 url_path=config.get('www', 'url') + '/' + config.get('local', 'json_path'),
                 life=life,
+                patches_path=config.get('local', 'patches_path'),
                 tree_path=config.get('local', 'tree_path'))
     f.run()
     life.exit()

--- a/contest/remote/lib/fetcher.py
+++ b/contest/remote/lib/fetcher.py
@@ -10,7 +10,7 @@ import time
 
 class Fetcher:
     def __init__(self, cb, cbarg, name, branches_url, results_path, url_path, tree_path,
-                 life, first_run="continue"):
+                 life, patches_path, first_run="continue"):
         self._cb = cb
         self._cbarg = cbarg
         self.name = name
@@ -23,6 +23,7 @@ class Fetcher:
         self._results_manifest = os.path.join(results_path, 'results.json')
 
         self._tree_path = tree_path
+        self._patches_path = patches_path
 
         # Set last date to something old
         self._last_date = datetime.datetime.now(datetime.UTC) - datetime.timedelta(weeks=1)
@@ -130,11 +131,21 @@ class Fetcher:
 
         print("Testing ", to_test)
         self._last_date = newest
+
+        if self._patches_path is not None:
+            subprocess.run('git restore .', cwd=self._tree_path,
+                           shell=True)
+
         # For now assume URL is in one of the remotes
         subprocess.run('git fetch --all --prune', cwd=self._tree_path,
                        shell=True)
         subprocess.run('git checkout ' + to_test["branch"],
                        cwd=self._tree_path, shell=True, check=True)
+
+        if self._patches_path is not None:
+            subprocess.run('git apply -v {}/*'.format(self._patches_path),
+                           cwd=self._tree_path, shell=True, check=True)
+
         self._clean_old_branches(branches, to_test["branch"])
         self._run_test(to_test)
 

--- a/contest/remote/vmksft-p.py
+++ b/contest/remote/vmksft-p.py
@@ -33,6 +33,7 @@ base_path=/common/path
 json_path=base-relative/path/to/json
 results_path=base-relative/path/to/raw/outputs
 tree_path=/root-path/to/kernel/git
+patches_path=/root-path/to/patches/dir
 [www]
 url=https://url-to-reach-base-path
 # Specific stuff
@@ -238,6 +239,7 @@ def main() -> None:
                 results_path=os.path.join(base_dir, config.get('local', 'json_path')),
                 url_path=config.get('www', 'url') + '/' + config.get('local', 'json_path'),
                 tree_path=config.get('local', 'tree_path'),
+                patches_path=config.get('local', 'patches_path'),
                 life=life,
                 first_run=config.get('executor', 'init', fallback="continue"))
     f.run()

--- a/contest/remote/vmksft.py
+++ b/contest/remote/vmksft.py
@@ -29,6 +29,7 @@ base_path=/common/path
 json_path=base-relative/path/to/json
 results_path=base-relative/path/to/raw/outputs
 tree_path=/root-path/to/kernel/git
+patches_path=/root-path/to/patches/dir
 [www]
 url=https://url-to-reach-base-path
 # Specific stuff
@@ -226,6 +227,7 @@ def main() -> None:
                 results_path=os.path.join(base_dir, config.get('local', 'json_path')),
                 url_path=config.get('www', 'url') + '/' + config.get('local', 'json_path'),
                 tree_path=config.get('local', 'tree_path'),
+                patches_path=config.get('local', 'patches_path'),
                 life=life,
                 first_run=config.get('executor', 'init', fallback="continue"))
     f.run()

--- a/contest/remote/vmtest.py
+++ b/contest/remote/vmtest.py
@@ -28,6 +28,7 @@ base_path=/common/path
 json_path=base-relative/path/to/json
 results_path=base-relative/path/to/raw/outputs
 tree_path=/root-path/to/kernel/git
+patches_path=/root-path/to/patches/dir
 [www]
 url=https://url-to-reach-base-path
 # Specific stuff
@@ -151,6 +152,7 @@ def main() -> None:
                 results_path=os.path.join(base_dir, config.get('local', 'json_path')),
                 url_path=config.get('www', 'url') + '/' + config.get('local', 'json_path'),
                 tree_path=config.get('local', 'tree_path'),
+                patches_path=config.get('local', 'patches_path'),
                 life=life,
                 first_run=config.get('executor', 'init', fallback="continue"))
     f.run()


### PR DESCRIPTION
In the tdc executor we need to change some configuration files before running the tests.
Initially we would apply these after cloning the repository but this is fragile as it can fail `git checkout` if patchwork has patches that touch these files.
The approach taken here seems to work fine for this case.

