### PR TITLE
contest: vm: 'slowdown' option to increase timeout

### DIFF
--- a/contest/remote/lib/vm.py
+++ b/contest/remote/lib/vm.py
@@ -30,6 +30,7 @@ paths=/extra/exec/PATH:/another/bin
 [vm]
 paths=/extra/exec/PATH:/another/bin
 ld_paths=/extra/lib/PATH:/another/lib
+exports=VAR1=val1,VAR2=val2
 configs=relative/path/config,another/config
 init_prompt=expected_on-boot#
 virtme_opt=--opt,--another one

--- a/contest/remote/lib/vm.py
+++ b/contest/remote/lib/vm.py
@@ -112,6 +112,25 @@ class VM:
         self.tree_cmd("make mrproper")
         self.tree_cmd("vng -v -b" + " -f ".join([""] + configs))
 
+    def _set_env(self):
+        # Install extra PATHs
+        if self.config.get('vm', 'paths', fallback=None):
+            self.cmd("export PATH=" + self.config.get('vm', 'paths') + ':$PATH')
+            self.drain_to_prompt()
+
+        if self.config.get('vm', 'ld_paths', fallback=None):
+            self.cmd("export LD_LIBRARY_PATH=" + self.config.get('vm', 'ld_paths') + ':$LD_LIBRARY_PATH')
+            self.drain_to_prompt()
+
+        exports = self.config.get('vm', 'exports', fallback=None)
+        if exports:
+            for export in exports.split(','):
+                self.cmd("export " + export)
+                self.drain_to_prompt()
+
+        self.cmd("env")
+        self.drain_to_prompt()
+
     def start(self, cwd=None):
         cmd = "vng -v -r arch/x86/boot/bzImage --user root"
         cmd = cmd.split(' ')
@@ -148,20 +167,7 @@ class VM:
         self.cmd("PS1='xx__-> '")
         self.drain_to_prompt()
 
-        # Install extra PATHs
-        if self.config.get('vm', 'paths', fallback=None):
-            self.cmd("export PATH=" + self.config.get('vm', 'paths') + ':$PATH')
-            self.drain_to_prompt()
-        if self.config.get('vm', 'ld_paths', fallback=None):
-            self.cmd("export LD_LIBRARY_PATH=" + self.config.get('vm', 'ld_paths') + ':$LD_LIBRARY_PATH')
-            self.drain_to_prompt()
-        exports = self.config.get('vm', 'exports', fallback=None)
-        if exports:
-            for export in exports.split(','):
-                self.cmd("export " + export)
-                self.drain_to_prompt()
-        self.cmd("env")
-        self.drain_to_prompt()
+        self._set_env()
 
     def stop(self):
         self.cmd("exit")

--- a/contest/remote/lib/vm.py
+++ b/contest/remote/lib/vm.py
@@ -29,6 +29,7 @@ url=https://url-to-reach-base-path
 paths=/extra/exec/PATH:/another/bin
 [vm]
 paths=/extra/exec/PATH:/another/bin
+ld_paths=/extra/lib/PATH:/another/lib
 configs=relative/path/config,another/config
 init_prompt=expected_on-boot#
 virtme_opt=--opt,--another one


### PR DESCRIPTION
When this option is set, two different env vars are set:

- `KSFT_MACHINE_SLOW`: some tests check if the env var is defined (no matter the value it is set to), and are then more tolerant with issues. No need to set this env var in the 'exports' option everywhere needed then.

- `kselftest_override_timeout`: the kselftest timeout is multiplied by the float value linked to this new 'slowdown' option. The kselftest's 'settings' file is read to get the custom timeout option. If not set, the default timeout of 45 seconds is used. Increasing the timeout is useful when the environment is "abnormally" slow, e.g. when using a bunch of debug kconfig. This is probably better to override the timeout instead of setting a huge value supporting such envs, not to have a too high value for "normal" environments, loosing the interest of "quickly" stopping a stalled test.

Note that the `_get_ksft_timeout()` method could maybe be moved to `vmksft`. I didn't do it as it is not clear to me if `vmksft-p` will be merged with `vmksft` or if the latter will be removed. Anyway, this ksft specific code is in a separated method. So if we want to move stuff, it should not be too hard :)

The 3 first commits are just some small fixes + preparation code.