### PR TITLE
fetcher: sort patches directory before applying

### DIFF
--- a/contest/remote/lib/fetcher.py
+++ b/contest/remote/lib/fetcher.py
@@ -143,7 +143,7 @@ class Fetcher:
                        cwd=self._tree_path, shell=True, check=True)
 
         if self._patches_path is not None:
-            for patch in os.listdir(self._patches_path):
+            for patch in sorted(os.listdir(self._patches_path)):
                 realpath = '{}/{}'.format(self._patches_path, patch)
                 subprocess.run('git apply -v {}'.format(realpath),
                                cwd=self._tree_path, shell=True)


### PR DESCRIPTION
os.listdir lists all the files in the patches directory, however the list is not ordered. This may cause patches to be applied in the wrong order.

To solve this sort the list to guarantee the correct application order.