### PR TITLE
Improve build failures

### DIFF
--- a/contest/remote/lib/vm.py
+++ b/contest/remote/lib/vm.py
@@ -95,6 +95,7 @@ class VM:
         self.log_err += stderr.decode("utf-8", "ignore")
         proc.stdout.close()
         proc.stderr.close()
+        return proc.returncode
 
     def build(self, extra_configs, override_configs=None):
         if self.log_out or self.log_err:
@@ -111,7 +112,13 @@ class VM:
         print(f"INFO{self.print_pfx} building kernel")
         # Make sure we rebuild, config and module deps can be stale otherwise
         self.tree_cmd("make mrproper")
-        self.tree_cmd("vng -v -b" + " -f ".join([""] + configs))
+
+        rc = self.tree_cmd("vng -v -b" + " -f ".join([""] + configs))
+        if rc != 0:
+            print(f"INFO{self.print_pfx} kernel build failed")
+            return False
+
+        return True
 
     def _get_ksft_timeout(self):
         default_timeout = 45 # from tools/testing/selftests/kselftest/runner.sh

--- a/contest/remote/vmksft-p.py
+++ b/contest/remote/vmksft-p.py
@@ -244,9 +244,18 @@ def test(binfo, rinfo, cbarg):
            rinfo['run-cookie']
     rinfo['link'] = link
     target = config.get('ksft', 'target')
+    grp_name = "selftests-" + namify(target)
 
     vm = VM(config)
-    vm.build([f"tools/testing/selftests/{target}/config"])
+
+    if vm.build([f"tools/testing/selftests/{target}/config"]) == False:
+        return [{
+            'test': 'build',
+            'group': grp_name,
+            'result': 'fail',
+            'link': '',
+        }]
+
     shutil.copy(os.path.join(config.get('local', 'tree_path'), '.config'),
                 results_path + '/config')
     vm.tree_cmd("make headers")
@@ -286,7 +295,6 @@ def test(binfo, rinfo, cbarg):
     for i in range(thr_cnt):
         threads[i].join()
 
-    grp_name = "selftests-" + namify(target)
     cases = []
     while not out_queue.empty():
         r = out_queue.get()


### PR DESCRIPTION
As we saw this week, build failures are not being reported nicely.
Try to improve it by reporting a real result for the run instead of an empty one.