### PR TITLE
contest: kunit: 'namify' the test names

### DIFF
--- a/contest/remote/kunit.py
+++ b/contest/remote/kunit.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 
 from core import NipaLifetime
-from lib import Fetcher
+from lib import Fetcher, namify
 
 
 """
@@ -94,16 +94,17 @@ def summary_flat(expected, got, sub_path=""):
     bad_tests = []
     for case in got["test_cases"]:
         code = str_to_code[case["status"]]
+        name = namify(case["name"])
 
-        exp = expected.get(got["name"], {}).get(case["name"])
+        exp = expected.get(got["name"], {}).get(name)
         if exp and exp == code:
             continue
 
         overall_code = max(code, overall_code)
-        results.append({'test': sub_path + case["name"],
+        results.append({'test': sub_path + name,
                         'result': code_to_str[code]})
         if code:
-            bad_tests.append(f"{got['name']} {case['name']} {case['status']}")
+            bad_tests.append(f"{got['name']} {name} {case['status']}")
 
     for sub_group in got["sub_groups"]:
         ov, bt, res = summary_flat(expected, sub_group, sub_path + sub_group["name"])

--- a/contest/remote/lib/fetcher.py
+++ b/contest/remote/lib/fetcher.py
@@ -154,3 +154,10 @@ class Fetcher:
     def run(self):
         while self.life.next_poll():
             self._run_once()
+
+
+def namify(what):
+    name = re.sub(r'[^0-9a-zA-Z]+', '-', what)
+    if name[-1] == '-':
+        name = name[:-1]
+    return name

--- a/contest/remote/vmksft-p.py
+++ b/contest/remote/vmksft-p.py
@@ -15,7 +15,7 @@ import time
 from core import NipaLifetime
 from lib import wait_loadavg
 from lib import CbArg
-from lib import Fetcher
+from lib import Fetcher, namify
 from lib import VM, new_vm, guess_indicators
 
 
@@ -56,13 +56,6 @@ group1 test1 skip
 group1 test3 fail
 group3 testV skip
 """
-
-
-def namify(what):
-    name = re.sub(r'[^0-9a-zA-Z]+', '-', what)
-    if name[-1] == '-':
-        name = name[:-1]
-    return name
 
 
 def get_prog_list(vm, target):


### PR DESCRIPTION
The new subtests have spaces in their name, e.g.
    
    example.example_params_test.example value 0
    
It sounds better to avoid these spaces and other unwanted chars, as the test name is used to identify the test.
    
This will break the tracking of failed tests, but it has just been broken a few days ago, probably the good time to do that again.