### PR TITLE
system-status: db: reverse order

### DIFF
--- a/system-status.py
+++ b/system-status.py
@@ -180,7 +180,7 @@ def add_db(result, cfg):
 
     with psql.cursor() as cur:
         cur.execute(f"SELECT ts,size FROM {tbl} ORDER BY id DESC LIMIT 40")
-        result["db"]["data"] = [ {'ts': t.isoformat(), 'size': s} for t, s in cur.fetchall() ]
+        result["db"]["data"] = [ {'ts': t.isoformat(), 'size': s} for t, s in reversed(cur.fetchall()) ]
 
 
 def main():


### PR DESCRIPTION
The list we get from the DB is reversed, to be able to easily limit it to 40 entries. To present the data in the right order in the JSON, we need to reverse them again.

The UI could also reverse them, but it sounds better to write the data in the right order instead.