### PR TITLE
contest: vm: add cmd to start VM in logs

### DIFF
--- a/contest/remote/lib/vm.py
+++ b/contest/remote/lib/vm.py
@@ -200,6 +200,7 @@ class VM:
             cmd += ["--cpus", cpus]
 
         print(f"INFO{self.print_pfx} VM starting:", " ".join(cmd))
+        self.log_out += "# " + " ".join(cmd) + "\n"
         self.p = self.tree_popen(cmd)
 
         for pipe in [self.p.stdout, self.p.stderr]:


### PR DESCRIPTION
In the logs, we can see the command used to build the VM, the selftests, etc. but not the one to run the VM.

The command is now added to `log_out`, which will be dumped later to the `stdout` file.

Note that we could also move the line adding `> TREE CMD:` to `log_out` from `tree_cmd()` to `tree_popen()`, but that will also add the `decoded_stacktrace.sh` command to `log_out`, which will not contain the output of this latter command as it will be redirected to another file. So maybe better **not** to modify `tree_popen()` I suppose.

Linked to this [discussion](https://lore.kernel.org/netdev/ZnE2zkSHyg5miJSq@nanopsycho.orion/T/) with @jpirko.