### PR TITLE
Mark `init_dummy_netdev` as deprecated

### DIFF
--- a/tests/patch/deprecated_api/deprecated_api.sh
+++ b/tests/patch/deprecated_api/deprecated_api.sh
@@ -4,7 +4,7 @@
 # Copyright (c) 2020 Facebook
 
 errors=( module_param )
-warnings=( "\Wdev_hold(" "\Wdev_put(" "\Wput_net(" "\Wget_net(" )
+warnings=( "\Wdev_hold(" "\Wdev_put(" "\Wput_net(" "\Wget_net(" "\Winit_dummy_netdev(" )
 
 res=0
 msg=""

--- a/tests/patch/deprecated_api/deprecated_api.sh
+++ b/tests/patch/deprecated_api/deprecated_api.sh
@@ -51,5 +51,10 @@ else
   msg="Found: ${msg:2}"
 fi
 
-echo -e "$msg" >&$DESC_FD
+if [[ -z $DESC_FD ]]
+then
+	echo -e "$msg"
+else
+	echo -e "$msg" >& $DESC_FD
+fi
 exit $res


### PR DESCRIPTION
I've tested it creating a patch using `init_dummy_netdev()` and running:

```
 ~/Devel/nipa/tests/patch/deprecated_api/deprecated_api.sh
Found: 'init_dummy_netdev(' was: 0 now: 1
```