### PR TITLE
docker: add lld/llvm

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
 	bison \
 	libssl-dev \
 	libelf-dev \
-	clang \
+	clang lld llvm \
 	sparse \
 	bc \
 	cpio \


### PR DESCRIPTION
These seem to be necessary (now?) for running clang builds, containing lld and llvm-ar respectively.