### PR TITLE
tests: build: run baseline build for Kconfig updates

### DIFF
--- a/tests/patch/build_32bit/build_32bit.sh
+++ b/tests/patch/build_32bit/build_32bit.sh
@@ -34,8 +34,10 @@ HEAD=$(git rev-parse HEAD)
 echo "Tree base:"
 git log -1 --pretty='%h ("%s")' HEAD~
 
-if [ x$FIRST_IN_SERIES == x0 ]; then
-    echo "Skip baseline build, not the first patch"
+if [ x$FIRST_IN_SERIES == x0 ] && \
+   ! git diff --name-only HEAD~ | grep -q -E "Kconfig$"
+then
+    echo "Skip baseline build, not the first patch and no Kconfig updates"
 else
     echo "Baseline building the tree"
 

--- a/tests/patch/build_allmodconfig_warn/build_allmodconfig.sh
+++ b/tests/patch/build_allmodconfig_warn/build_allmodconfig.sh
@@ -34,8 +34,10 @@ HEAD=$(git rev-parse HEAD)
 echo "Tree base:"
 git log -1 --pretty='%h ("%s")' HEAD~
 
-if [ x$FIRST_IN_SERIES == x0 ]; then
-    echo "Skip baseline build, not the first patch"
+if [ x$FIRST_IN_SERIES == x0 ] && \
+   ! git diff --name-only HEAD~ | grep -q -E "Kconfig$"
+then
+    echo "Skip baseline build, not the first patch and no Kconfig updates"
 else
     echo "Baseline building the tree"
 

--- a/tests/patch/build_clang/build_clang.sh
+++ b/tests/patch/build_clang/build_clang.sh
@@ -27,8 +27,10 @@ HEAD=$(git rev-parse HEAD)
 echo "Tree base:"
 git log -1 --pretty='%h ("%s")' HEAD~
 
-if [ x$FIRST_IN_SERIES == x0 ]; then
-    echo "Skip baseline build, not the first patch"
+if [ x$FIRST_IN_SERIES == x0 ] && \
+   ! git diff --name-only HEAD~ | grep -q -E "Kconfig$"
+then
+    echo "Skip baseline build, not the first patch and no Kconfig updates"
 else
     echo "Baseline building the tree"
 


### PR DESCRIPTION
Some Kconfig updates may result in .config changes which may in turn alter the preprocessor output of header files, which may in turn result in file rebuilds.

Due to the incremental way in which these tests may be run over a patchset this can result in inaccurate incumbent warning counts for patches, other than the first patch in a series for which a baseline build already occurs. This can, in turn, lead to false positives about new warnings being introduced.

Some discussion of this problem can be found at:
- Re: [PATCH v3 08/12] testing: net-drv: add basic shaper test https://lore.kernel.org/netdev/20240808122042.GA3067851@kernel.org/

While possibly heavy handed, the solution in this patch does seem address the problem. And can always be improved upon later.