### PR TITLE
contest: vmksft-p: allow dup spaces in nested tests

### DIFF
--- a/contest/remote/vmksft-p.py
+++ b/contest/remote/vmksft-p.py
@@ -73,7 +73,7 @@ def _parse_nested_tests(full_run):
     tests = []
     nested_tests = False
 
-    result_re = re.compile(r"(not )?ok (\d+)( -)? ([^#]*[^ ])( # )?([^ ].*)?$")
+    result_re = re.compile(r"(not )?ok (\d+)( -)? ([^#]*[^ ])( +# +)?([^ ].*)?$")
     time_re = re.compile(r"time=(\d+)ms")
 
     for line in full_run.split('\n'):


### PR DESCRIPTION
Jakub recently reported that MPTCP nested tests were not properly parsed due to the presence of multiple whitespaces before the directive delimiter (`#`), e.g.

    ok 46 - mptcp_connect: peek mode: saveWithPeek: ns1 MPTCP -> ns1 (10.0.1.1:10043      ) TCP   # time=5693ms

TAP 14 explicitly allow having multiple whitespaces around the directive delimiter, but TAP 13 and KTAP doesn't mention anything about them. Anyway, it is easy to supported them by tweaking the regex to allow multiple whitespaces around the `#` character.

Suggested-by: Jakub Kicinski