### PR TITLE
contest: vm: get `tree_path` config only once

### DIFF
--- a/contest/remote/lib/vm.py
+++ b/contest/remote/lib/vm.py
@@ -116,12 +116,11 @@ class VM:
         default_timeout = 45 # from tools/testing/selftests/kselftest/runner.sh
 
         targets = self.config.get('ksft', 'target', fallback=None)
-        tree_path = self.config.get('local', 'tree_path', fallback=None)
-        if not targets or not tree_path:
+        if not targets:
             return default_timeout
         target = targets.split()[0]
 
-        settings_path = f'{tree_path}/tools/testing/selftests/{target}/settings'
+        settings_path = f'{self.tree_path}/tools/testing/selftests/{target}/settings'
         if not os.path.isfile(settings_path):
             return default_timeout
 


### PR DESCRIPTION
`tree_path` config is fetched at the init phase, no need to get it again later, simply use `self.tree_path`.

This is a simple fix I spot when working on something unrelated. Sending it separately to avoid noise on the other change.