### PR TITLE
contest: vm: capture code coverage

### DIFF
--- a/contest/remote/vmksft-p.py
+++ b/contest/remote/vmksft-p.py
@@ -218,6 +218,7 @@ def _vm_thread(config, results_path, thr_id, hard_stop, in_queue, out_queue):
             vm = None
 
     if vm is not None:
+        vm.capture_gcov(results_path + f'/kernel-thr{thr_id}-{vm_id}.lcov')
         vm.stop()
         vm.dump_log(results_path + f'/vm-stop-thr{thr_id}-{vm_id}')
     return


### PR DESCRIPTION
Code coverage is a valuable info to get to know how much we can trust a test suite, and easily find out what needs to be improved.

Here is what it looks like for MPTCP: https://ci-results.mptcp.dev/lcov/export/index.html
(This is also visible on [Coveralls](https://coveralls.io/github/multipath-tcp/mptcp_net-next).)

It is quite easy to get such info with the kernel, but it needs extra steps on the host (maybe we can switch this PR to a Draft):

- The kernel needs to be compiled with `GCOV_KERNEL=y`: this is handled by the modification suggested here, using `vng -b --configitem`. It requires virtme-ng >=1.26.

- GCOV profile also needs to be enabled, either with `GCOV_PROFILE_ALL=y` kconfig, but it is not recommended, or `GCOV_PROFILE := y` set in the `Makefile`'s. I recommend adding a new commit to the branches that are created by NIPA, with a content that is similar to this (`GCOV_PROFILE` added in the header section to avoid future conflicts):
```patch
From c6d5f01a49ecd545d25ee638cb9a976045145e5a Mon Sep 17 00:00:00 2001
From: "Matthieu Baerts (NGI0)" <matttbe@kernel.org>
Date: Fri, 27 Sep 2024 17:59:50 +0200
Subject: [PATCH] NIPA: enable GCOV support for net and drivers/net

This limit the GCOV support to the Networking subsystem.

Signed-off-by: Matthieu Baerts (NGI0) <matttbe@kernel.org>
---
 drivers/net/Makefile | 3 +++
 net/Makefile         | 4 ++++
 2 files changed, 7 insertions(+)

diff --git a/drivers/net/Makefile b/drivers/net/Makefile
index 13743d0e83b5..a99351433b2f 100644
--- a/drivers/net/Makefile
+++ b/drivers/net/Makefile
@@ -3,6 +3,9 @@
 # Makefile for the Linux network device drivers.
 #
 
+# enable GCOV support for NIPA
+GCOV_PROFILE := y
+
 #
 # Networking Core Drivers
 #
diff --git a/net/Makefile b/net/Makefile
index 65bb8c72a35e..6c05a02b3e30 100644
--- a/net/Makefile
+++ b/net/Makefile
@@ -2,6 +2,10 @@
 #
 # Makefile for the linux networking.
 #
+
+# enable GCOV support for NIPA
+GCOV_PROFILE := y
+
 # 2 Sep 2000, Christoph Hellwig <hch@infradead.org>
 # Rewritten to use lists instead of if-statements.
 #
-- 
2.45.2
```

- Before stopping the VM, the LCOV file is now captured using the `lcov` tool, version >= 2.0 is recommended. This tool needs to be added on the machines running the tests, the scripts are now going to use them from the VM.

- The last step is to use `genhtml` from the LCOV project to generate an HTML version using all the `.lcov` files. (It could be done per LCOV file, but that will then only show the coverage per VM, not the global one.). I guess this needs to be done in a separated script, after the end of all tests, using all the collected `.lcov` file, but it is not clear to me how to do that. Here is the command that needs to be executed:
```shell
BRANCH= # TODO: branch name
OUT=    # TODO: output dir
genhtml -j "$(nproc)" -t "${BRANCH}" --dark-mode \
	--include '/net/' --legend \
	--function-coverage --branch-coverage --keep-going \
	-o "${OUT}" */kernel-thr*.lcov
```

This GCOV support is disabled by default. It can be enabled via `vm.gcov=on`. I suggest keeping it off by default, and switch it to on later when everything is in place.

Note: on MPTCP side, I use a simple [Docker image](https://github.com/multipath-tcp/docker-lcov-alpine/blob/main/Dockerfile). If it is difficult to use LCOV >=2.0 on your side, a workaround is to add a file called `lcov` somewhere in your `$PATH` with this content (+ a symlink for `genhtml`):
```shell
docker run --pull always --rm --workdir "${PWD}" -v "${PWD}:${PWD}" \
       mptcp/docker-lcov-alpine:latest \
       "$(basename "${0}")" "${@}"
```

One last thing: it might be good to also add this support when running the KUnit tests, but it is not clear to me how to integrate with `tools/testing/kunit/kunit.py`.