### PR TITLE
checkpatch: remove custom max line length

### DIFF
--- a/tests/patch/checkpatch/checkpatch.sh
+++ b/tests/patch/checkpatch/checkpatch.sh
@@ -13,7 +13,7 @@ CAMELCASE
 
 tmpfile=$(mktemp)
 
-./scripts/checkpatch.pl --strict --max-line-length=80 --ignore=$IGNORED -g HEAD | tee $tmpfile
+./scripts/checkpatch.pl --strict --ignore=$IGNORED -g HEAD | tee $tmpfile
 
 grep 'total: 0 errors, 0 warnings, 0 checks' $tmpfile
 ret=$?


### PR DESCRIPTION
I noticed that the recent trend is to avoid coding style differences between subtrees, e.g. commit [82b8000c28b5](https://github.com/torvalds/linux/commit/82b8000c28b5) ("net: drop special comment style") in the kernel repository.

I then wonder if this netdev specific limit still makes sense today. I didn't find anything about it in the kernel documentation, nor in the commit introducing it here in this repo: commit 950c7e3 ("bring back 80 char max len").

On MPTCP side, the preferred limit on the length of a single line is 80 columns. But when this improves the readability, some lines are a bit over 80 chars, e.g. for the parameters of a function, comments next to fields of a structure, etc. I don't think we abuse of this, but we regularly have warnings on Patchwork that we are over the 80 chars limit. I don't think we ever had any comments about that, that's why we continued to use the default limit, while still keeping most of the code under the 80 chars limit.

Then is it fine to drop this limit, and use the default one? Or should we really try to limit the length to 80 chars and the documentation needs to be updated instead?