### PR TITLE
docker: install gawk

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
 	ccache \
 	flex \
 	bison \
+	gawk \
 	libssl-dev \
 	libelf-dev \
 	clang lld llvm \


### PR DESCRIPTION
It's explicitly needed by the kernel, but apparently not always pulled in.