### PR TITLE
tree_match: handle bpf-next/net

### DIFF
--- a/netdev/tree_match.py
+++ b/netdev/tree_match.py
@@ -10,7 +10,7 @@ from core import log, log_open_sec, log_end_sec
 
 
 def series_tree_name_direct(series):
-    for t in ['net-next', 'net', 'bpf-next', 'bpf']:
+    for t in ['net-next', 'bpf-next', 'net', 'bpf']:
         if re.match(r'\[.*{pfx}.*\]'.format(pfx=t), series.subject):
             return t
 


### PR DESCRIPTION
For a few months now [1], BPF patches that are "Networking related" should have the "bpf-next/net" prefix.

With the previous order, the PW poller was considering this prefix as "for net", leading to these results on Patchwork [2]:

   Context              |  Check  |  Description
  ----------------------|---------|------------------------------
  netdev/tree_selection | success | Clearly marked for net
  netdev/apply          | fail    | Patch does not apply to net-0

By changing the order of the list, such patches with "[bpf-next/net]" will be marked for "bpf-next", and they will not be applied locally like it was the case before with "bpf-next" patches.

Link: https://lore.kernel.org/netdev/CAADnVQJgwGh+Jf=DUFuX28R2bpWVezigQYObNoKJT8UbqekOHA@mail.gmail.com/ [1]
Link: https://patchwork.kernel.org/project/netdevbpf/patch/c02fda3177b34f9e74a044833fda9761627f4d07.1730338692.git.tanggeliang@kylinos.cn/ [2]