### PR TITLE
pw_poller: make list module configurable

### DIFF
--- a/netdev/__init__.py
+++ b/netdev/__init__.py
@@ -12,3 +12,6 @@ from .tree_match import series_tree_name_direct, \
     series_tree_name_should_be_local, \
     series_is_a_fix_for, \
     series_needs_async
+
+current_tree = 'net'
+next_tree = 'net-next'


### PR DESCRIPTION
There only is a 'netdev' module now, but make that configuration so we can add other modules (i.e. wireless) later. Put the names of trees into the module instead of hard-coding.