### PR TITLE
pw_poller: use configured trees for subject tag match

### DIFF
--- a/netdev/tree_match.py
+++ b/netdev/tree_match.py
@@ -9,8 +9,8 @@ import re
 from core import log, log_open_sec, log_end_sec
 
 
-def series_tree_name_direct(series):
-    for t in ['net-next', 'bpf-next', 'net', 'bpf']:
+def series_tree_name_direct(conf_trees, series):
+    for t in conf_trees:
         if re.match(r'\[.*{pfx}.*\]'.format(pfx=t), series.subject):
             return t
 

--- a/pw_poller.py
+++ b/pw_poller.py
@@ -92,7 +92,7 @@ class PwPoller:
             pass
 
     def _series_determine_tree(self, s: PwSeries) -> str:
-        s.tree_name = self.list_module.series_tree_name_direct(s)
+        s.tree_name = self.list_module.series_tree_name_direct(self._trees.keys(), s)
         s.tree_mark_expected = True
         s.tree_marked = bool(s.tree_name)
 


### PR DESCRIPTION
Feels wrong to have this hard-coded, even in a plugin.