### PR TITLE
tests: kernel-doc: handle pull requests better

### DIFF
--- a/tests/patch/kdoc/kdoc.sh
+++ b/tests/patch/kdoc/kdoc.sh
@@ -8,7 +8,7 @@ tmpfile_o=$(mktemp)
 tmpfile_n=$(mktemp)
 rc=0
 
-files=$(git show --pretty="" --name-only HEAD)
+files=$(git diff HEAD^ --pretty= --name-only)
 
 HEAD=$(git rev-parse HEAD)
 


### PR DESCRIPTION
For pull requests, it only tests files changed during the merge commit itself, which is a bit weird, especially as the automatic merge won't be able to resolve conflicts. Use "git diff" instead of "git show" to build the list of changed files.