### PR TITLE
tests: use correct `HEAD` to list files

### DIFF
--- a/tests/patch/pylint/pylint.sh
+++ b/tests/patch/pylint/pylint.sh
@@ -8,8 +8,8 @@ pr() {
     echo " ====== $@ ======" | tee -a /dev/stderr
 }
 
-# If it doesn't touch .py files, don't bother. Ignore created and deleted.
-if ! git show --diff-filter=AM --pretty="" --name-only HEAD | grep -q -E "\.py$"
+# If it doesn't touch .py files, don't bother. Ignore deleted.
+if ! git show --diff-filter=AM --pretty="" --name-only "${HEAD}" | grep -q -E "\.py$"
 then
     echo "No python scripts touched, skip" >&$DESC_FD
     exit 0
@@ -28,7 +28,8 @@ git log -1 --pretty='%h ("%s")' HEAD
 pr "Checking before the patch"
 git checkout -q HEAD~
 
-for f in $(git show --diff-filter=M --pretty="" --name-only HEAD | grep -E "\.py$"); do
+# Also ignore created, as not present in the parent commit
+for f in $(git show --diff-filter=M --pretty="" --name-only "${HEAD}" | grep -E "\.py$"); do
     pylint $f | tee -a $tmpfile_o
 done
 
@@ -38,7 +39,7 @@ incumbent_w=$(grep -i -c ": [WC][0-9][0-9][0-9][0-9]: " $tmpfile_o)
 pr "Checking the tree with the patch"
 git checkout -q $HEAD
 
-for f in $(git show --diff-filter=AM --pretty="" --name-only HEAD | grep -E "\.py$"); do
+for f in $(git show --diff-filter=AM --pretty="" --name-only "${HEAD}" | grep -E "\.py$"); do
     pylint $f | tee -a $tmpfile_n
 done
 

--- a/tests/patch/shellcheck/shellcheck.sh
+++ b/tests/patch/shellcheck/shellcheck.sh
@@ -8,8 +8,8 @@ pr() {
     echo " ====== $@ ======" | tee -a /dev/stderr
 }
 
-# If it doesn't touch .sh files, don't bother. Ignore created and deleted.
-if ! git show --diff-filter=AM --pretty="" --name-only HEAD | grep -q -E "\.sh$"
+# If it doesn't touch .sh files, don't bother. Ignore deleted.
+if ! git show --diff-filter=AM --pretty="" --name-only "${HEAD}" | grep -q -E "\.sh$"
 then
     echo "No shell scripts touched, skip" >&$DESC_FD
     exit 0
@@ -28,7 +28,8 @@ git log -1 --pretty='%h ("%s")' HEAD
 pr "Checking before the patch"
 git checkout -q HEAD~
 
-for f in $(git show --diff-filter=M --pretty="" --name-only HEAD | grep -E "\.sh$"); do
+# Also ignore created, as not present in the parent commit
+for f in $(git show --diff-filter=M --pretty="" --name-only "${HEAD}" | grep -E "\.sh$"); do
     (
 	echo "Checking $f"
 	echo
@@ -45,7 +46,7 @@ incumbent_w=$(grep -i -c "SC[0-9]* (" $tmpfile_o)
 pr "Building the tree with the patch"
 git checkout -q $HEAD
 
-for f in $(git show --diff-filter=AM --pretty="" --name-only HEAD | grep -E "\.sh$"); do
+for f in $(git show --diff-filter=AM --pretty="" --name-only "${HEAD}" | grep -E "\.sh$"); do
     (
 	echo "Checking $f"
 	echo

--- a/tests/patch/yamllint/yamllint.sh
+++ b/tests/patch/yamllint/yamllint.sh
@@ -8,8 +8,8 @@ pr() {
     echo " ====== $@ ======" | tee -a /dev/stderr
 }
 
-# If it doesn't touch .yaml files, don't bother. Ignore created and deleted.
-if ! git show --diff-filter=AM --pretty="" --name-only HEAD | grep -q -E "\.yaml$"
+# If it doesn't touch .yaml files, don't bother. Ignore deleted.
+if ! git show --diff-filter=AM --pretty="" --name-only "${HEAD}" | grep -q -E "\.yaml$"
 then
     echo "No YAML files touched, skip" >&$DESC_FD
     exit 0
@@ -28,7 +28,8 @@ git log -1 --pretty='%h ("%s")' HEAD
 pr "Checking before the patch"
 git checkout -q HEAD~
 
-for f in $(git show --diff-filter=M --pretty="" --name-only HEAD | grep -E "\.yaml$"); do
+# Also ignore created, as not present in the parent commit
+for f in $(git show --diff-filter=M --pretty="" --name-only "${HEAD}" | grep -E "\.yaml$"); do
     yamllint $f | tee -a $tmpfile_o
 done
 
@@ -38,7 +39,7 @@ incumbent_w=$(grep -i -c " warning " $tmpfile_o)
 pr "Checking the tree with the patch"
 git checkout -q $HEAD
 
-for f in $(git show --diff-filter=AM --pretty="" --name-only HEAD | grep -E "\.yaml$"); do
+for f in $(git show --diff-filter=AM --pretty="" --name-only "${HEAD}" | grep -E "\.yaml$"); do
     yamllint $f | tee -a $tmpfile_n
 done
 


### PR DESCRIPTION
When checking the files before the patch, after a checkout to `HEAD~`, it is required to use the previous `HEAD`, not the new one to look at the same files and not others.

While at it, always use the `$HEAD` variable, and also fix a related comment + added an extra one to explain the diff.