### PR TITLE
Shellcheck warnings

### DIFF
--- a/tests/patch/pylint/pylint.sh
+++ b/tests/patch/pylint/pylint.sh
@@ -5,13 +5,13 @@ HEAD=$(git rev-parse HEAD)
 rc=0
 
 pr() {
-    echo " ====== $@ ======" | tee -a /dev/stderr
+    echo " ====== $* ======" | tee -a /dev/stderr
 }
 
 # If it doesn't touch .py files, don't bother. Ignore deleted.
 if ! git show --diff-filter=AM --pretty="" --name-only "${HEAD}" | grep -q -E "\.py$"
 then
-    echo "No python scripts touched, skip" >&$DESC_FD
+    echo "No python scripts touched, skip" >&"$DESC_FD"
     exit 0
 fi
 
@@ -30,35 +30,35 @@ git checkout -q HEAD~
 
 # Also ignore created, as not present in the parent commit
 for f in $(git show --diff-filter=M --pretty="" --name-only "${HEAD}" | grep -E "\.py$"); do
-    pylint $f | tee -a $tmpfile_o
+    pylint "$f" | tee -a "$tmpfile_o"
 done
 
-incumbent=$(grep -i -c ": E[0-9][0-9][0-9][0-9]: " $tmpfile_o)
-incumbent_w=$(grep -i -c ": [WC][0-9][0-9][0-9][0-9]: " $tmpfile_o)
+incumbent=$(grep -i -c ": E[0-9][0-9][0-9][0-9]: " "$tmpfile_o")
+incumbent_w=$(grep -i -c ": [WC][0-9][0-9][0-9][0-9]: " "$tmpfile_o")
 
 pr "Checking the tree with the patch"
-git checkout -q $HEAD
+git checkout -q "$HEAD"
 
 for f in $(git show --diff-filter=AM --pretty="" --name-only "${HEAD}" | grep -E "\.py$"); do
-    pylint $f | tee -a $tmpfile_n
+    pylint "$f" | tee -a "$tmpfile_n"
 done
 
-current=$(grep -i -c ": E[0-9][0-9][0-9][0-9]: " $tmpfile_n)
-current_w=$(grep -i -c ": [WC][0-9][0-9][0-9][0-9]: " $tmpfile_n)
+current=$(grep -i -c ": E[0-9][0-9][0-9][0-9]: " "$tmpfile_n")
+current_w=$(grep -i -c ": [WC][0-9][0-9][0-9][0-9]: " "$tmpfile_n")
 
-echo "Errors before: $incumbent (+warn: $incumbent_w) this patch: $current (+warn: $current_w)" >&$DESC_FD
+echo "Errors before: $incumbent (+warn: $incumbent_w) this patch: $current (+warn: $current_w)" >&"$DESC_FD"
 
-if [ $current_w -gt $incumbent_w ]; then
+if [ "$current_w" -gt "$incumbent_w" ]; then
     echo "New warnings added" 1>&2
 
     rc=250
 fi
 
-if [ $current -gt $incumbent ]; then
-  echo "New errors added" 1>&2
-  diff -U 0 $tmpfile_o $tmpfile_n 1>&2
+if [ "$current" -gt "$incumbent" ]; then
+    echo "New errors added" 1>&2
+    diff -U 0 "$tmpfile_o" "$tmpfile_n" 1>&2
 
-  rc=1
+    rc=1
 fi
 
 rm "$tmpfile_o" "$tmpfile_n"

--- a/tests/patch/pylint/pylint.sh
+++ b/tests/patch/pylint/pylint.sh
@@ -48,17 +48,17 @@ current_w=$(grep -i -c ": [WC][0-9][0-9][0-9][0-9]: " $tmpfile_n)
 
 echo "Errors before: $incumbent (+warn: $incumbent_w) this patch: $current (+warn: $current_w)" >&$DESC_FD
 
+if [ $current_w -gt $incumbent_w ]; then
+    echo "New warnings added" 1>&2
+
+    rc=250
+fi
+
 if [ $current -gt $incumbent ]; then
   echo "New errors added" 1>&2
   diff -U 0 $tmpfile_o $tmpfile_n 1>&2
 
   rc=1
-fi
-
-if [ $current_w -gt $incumbent_w ]; then
-    echo "New warnings added" 1>&2
-
-    rc=250
 fi
 
 rm "$tmpfile_o" "$tmpfile_n"

--- a/tests/patch/shellcheck/shellcheck.sh
+++ b/tests/patch/shellcheck/shellcheck.sh
@@ -90,17 +90,17 @@ done
 
 echo "Errors before: $incumbent (+warn: $incumbent_w) this patch: $current (+warn: $current_w)" >&$DESC_FD
 
+if [ $current_w -gt $incumbent_w ]; then
+    echo "New warnings added" 1>&2
+
+    rc=250
+fi
+
 if [ $current -gt $incumbent ]; then
   echo "New errors added" 1>&2
   diff -U 0 $tmpfile_o $tmpfile_n 1>&2
 
   rc=1
-fi
-
-if [ $current_w -gt $incumbent_w ]; then
-    echo "New warnings added" 1>&2
-
-    rc=250
 fi
 
 rm "$tmpfile_o"* "$tmpfile_n"*

--- a/tests/patch/shellcheck/shellcheck.sh
+++ b/tests/patch/shellcheck/shellcheck.sh
@@ -5,13 +5,13 @@ HEAD=$(git rev-parse HEAD)
 rc=0
 
 pr() {
-    echo " ====== $@ ======" | tee -a /dev/stderr
+    echo " ====== $* ======" | tee -a /dev/stderr
 }
 
 # If it doesn't touch .sh files, don't bother. Ignore deleted.
 if ! git show --diff-filter=AM --pretty="" --name-only "${HEAD}" | grep -q -E "\.sh$"
 then
-    echo "No shell scripts touched, skip" >&$DESC_FD
+    echo "No shell scripts touched, skip" >&"$DESC_FD"
     exit 0
 fi
 
@@ -31,43 +31,43 @@ git checkout -q HEAD~
 # Also ignore created, as not present in the parent commit
 for f in $(git show --diff-filter=M --pretty="" --name-only "${HEAD}" | grep -E "\.sh$"); do
     (
-	sha=$(echo $f | sha256sum | awk '{print $1}')
+	sha=$(echo "$f" | sha256sum | awk '{print $1}')
 	echo "Checking $f - $sha"
 	echo
 
-	cd $(dirname $f)
+	cd "$(dirname "$f")" || exit 1
 	sha="${tmpfile_o}_${sha}"
 	rm -f "${sha}"
-	shellcheck -x $(basename $f) | tee -a "${tmpfile_o}" "${sha}"
+	shellcheck -x "$(basename "$f")" | tee -a "${tmpfile_o}" "${sha}"
 	echo
     )
 done
 
 # ex: SC3045 (warning): In POSIX sh, printf -v is undefined.
 # severity: error, warning, info, style
-incumbent=$(grep -c " (error):" $tmpfile_o)
-incumbent_w=$(grep -c " (warning):" $tmpfile_o)
+incumbent=$(grep -c " (error):" "$tmpfile_o")
+incumbent_w=$(grep -c " (warning):" "$tmpfile_o")
 
-pr "Building the tree with the patch"
-git checkout -q $HEAD
+pr "Checking the tree with the patch"
+git checkout -q "$HEAD"
 
 for f in $(git show --diff-filter=AM --pretty="" --name-only "${HEAD}" | grep -E "\.sh$"); do
     (
-	sha=$(echo $f | sha256sum | awk '{print $1}')
+	sha=$(echo "$f" | sha256sum | awk '{print $1}')
 	echo "Checking $f - $sha"
 	echo
 
-	cd $(dirname $f)
+	cd "$(dirname "$f")" || exit 1
 	sha="${tmpfile_n}_${sha}"
 	rm -f "${sha}"
-	shellcheck -x $(basename $f) | tee -a "${tmpfile_n}" "${sha}"
+	shellcheck -x "$(basename "$f")" | tee -a "${tmpfile_n}" "${sha}"
 	echo
     )
 done
 
 # severity: error, warning, info, style
-current=$(grep -c " (error):" $tmpfile_n)
-current_w=$(grep -c " (warning):" $tmpfile_n)
+current=$(grep -c " (error):" "$tmpfile_n")
+current_w=$(grep -c " (warning):" "$tmpfile_n")
 
 # if a file was compliant before or is new, mark everything as error to keep it good.
 for f in "${tmpfile_n}_"*; do
@@ -88,19 +88,19 @@ for f in "${tmpfile_n}_"*; do
     current=$((current + extra))
 done
 
-echo "Errors before: $incumbent (+warn: $incumbent_w) this patch: $current (+warn: $current_w)" >&$DESC_FD
+echo "Errors before: $incumbent (+warn: $incumbent_w) this patch: $current (+warn: $current_w)" >&"$DESC_FD"
 
-if [ $current_w -gt $incumbent_w ]; then
+if [ "$current_w" -gt "$incumbent_w" ]; then
     echo "New warnings added" 1>&2
 
     rc=250
 fi
 
-if [ $current -gt $incumbent ]; then
-  echo "New errors added" 1>&2
-  diff -U 0 $tmpfile_o $tmpfile_n 1>&2
+if [ "$current" -gt "$incumbent" ]; then
+    echo "New errors added" 1>&2
+    diff -U 0 "$tmpfile_o" "$tmpfile_n" 1>&2
 
-  rc=1
+    rc=1
 fi
 
 rm "$tmpfile_o"* "$tmpfile_n"*

--- a/tests/patch/shellcheck/shellcheck.sh
+++ b/tests/patch/shellcheck/shellcheck.sh
@@ -40,8 +40,10 @@ for f in $(git show --diff-filter=M --pretty="" --name-only "${HEAD}" | grep -E 
     )
 done
 
-incumbent=$(grep -i -c "(error)" $tmpfile_o)
-incumbent_w=$(grep -i -c "SC[0-9]* (" $tmpfile_o)
+# ex: SC3045 (warning): In POSIX sh, printf -v is undefined.
+# severity: error, warning, info, style
+incumbent=$(grep -c " (error):" $tmpfile_o)
+incumbent_w=$(grep -c " (warning):" $tmpfile_o)
 
 pr "Building the tree with the patch"
 git checkout -q $HEAD
@@ -57,8 +59,9 @@ for f in $(git show --diff-filter=AM --pretty="" --name-only "${HEAD}" | grep -E
     )
 done
 
-current=$(grep -i -c "(error)" $tmpfile_n)
-current_w=$(grep -i -c "SC[0-9]* (" $tmpfile_n)
+# severity: error, warning, info, style
+current=$(grep -c " (error):" $tmpfile_n)
+current_w=$(grep -c " (warning):" $tmpfile_n)
 
 echo "Errors before: $incumbent (+warn: $incumbent_w) this patch: $current (+warn: $current_w)" >&$DESC_FD
 

--- a/tests/patch/yamllint/yamllint.sh
+++ b/tests/patch/yamllint/yamllint.sh
@@ -48,17 +48,17 @@ current_w=$(grep -i -c " warning " $tmpfile_n)
 
 echo "Errors before: $incumbent (+warn: $incumbent_w) this patch: $current (+warn: $current_w)" >&$DESC_FD
 
+if [ $current_w -gt $incumbent_w ]; then
+    echo "New warnings added" 1>&2
+
+    rc=250
+fi
+
 if [ $current -gt $incumbent ]; then
   echo "New errors added" 1>&2
   diff -U 0 $tmpfile_o $tmpfile_n 1>&2
 
   rc=1
-fi
-
-if [ $current_w -gt $incumbent_w ]; then
-    echo "New warnings added" 1>&2
-
-    rc=250
 fi
 
 rm "$tmpfile_o" "$tmpfile_n"

--- a/tests/patch/yamllint/yamllint.sh
+++ b/tests/patch/yamllint/yamllint.sh
@@ -5,13 +5,13 @@ HEAD=$(git rev-parse HEAD)
 rc=0
 
 pr() {
-    echo " ====== $@ ======" | tee -a /dev/stderr
+    echo " ====== $* ======" | tee -a /dev/stderr
 }
 
 # If it doesn't touch .yaml files, don't bother. Ignore deleted.
 if ! git show --diff-filter=AM --pretty="" --name-only "${HEAD}" | grep -q -E "\.yaml$"
 then
-    echo "No YAML files touched, skip" >&$DESC_FD
+    echo "No YAML files touched, skip" >&"$DESC_FD"
     exit 0
 fi
 
@@ -30,35 +30,35 @@ git checkout -q HEAD~
 
 # Also ignore created, as not present in the parent commit
 for f in $(git show --diff-filter=M --pretty="" --name-only "${HEAD}" | grep -E "\.yaml$"); do
-    yamllint $f | tee -a $tmpfile_o
+    yamllint "$f" | tee -a "$tmpfile_o"
 done
 
-incumbent=$(grep -i -c " error " $tmpfile_o)
-incumbent_w=$(grep -i -c " warning " $tmpfile_o)
+incumbent=$(grep -i -c " error " "$tmpfile_o")
+incumbent_w=$(grep -i -c " warning " "$tmpfile_o")
 
 pr "Checking the tree with the patch"
-git checkout -q $HEAD
+git checkout -q "$HEAD"
 
 for f in $(git show --diff-filter=AM --pretty="" --name-only "${HEAD}" | grep -E "\.yaml$"); do
-    yamllint $f | tee -a $tmpfile_n
+    yamllint "$f" | tee -a "$tmpfile_n"
 done
 
-current=$(grep -i -c " error " $tmpfile_n)
-current_w=$(grep -i -c " warning " $tmpfile_n)
+current=$(grep -i -c " error " "$tmpfile_n")
+current_w=$(grep -i -c " warning " "$tmpfile_n")
 
-echo "Errors before: $incumbent (+warn: $incumbent_w) this patch: $current (+warn: $current_w)" >&$DESC_FD
+echo "Errors before: $incumbent (+warn: $incumbent_w) this patch: $current (+warn: $current_w)" >&"$DESC_FD"
 
-if [ $current_w -gt $incumbent_w ]; then
+if [ "$current_w" -gt "$incumbent_w" ]; then
     echo "New warnings added" 1>&2
 
     rc=250
 fi
 
-if [ $current -gt $incumbent ]; then
-  echo "New errors added" 1>&2
-  diff -U 0 $tmpfile_o $tmpfile_n 1>&2
+if [ "$current" -gt "$incumbent" ]; then
+    echo "New errors added" 1>&2
+    diff -U 0 "$tmpfile_o" "$tmpfile_n" 1>&2
 
-  rc=1
+    rc=1
 fi
 
 rm "$tmpfile_o" "$tmpfile_n"


### PR DESCRIPTION
Here are a few modifications around the new test scripts:
- shellcheck: do not take info/style into account for the warnings, only warnings
- shellcheck: if the file is new or was compliant, complain about everything
- *: return rc=1 instead of rc=250 when there are new errors and new warnings
- *: cleanup to get them shellcheck compliant (a lot of noise...)