### PR TITLE
tests: kdoc: improve comparison and output

### DIFF
--- a/tests/patch/kdoc/kdoc.sh
+++ b/tests/patch/kdoc/kdoc.sh
@@ -4,8 +4,41 @@
 # Copyright (C) 2019 Netronome Systems, Inc.
 # Copyright (c) 2020 Facebook
 
+# Cleanup warnings by merging lines which end with ':' to their referenced
+# line content, and sorting the output carefully to ensure that the entries
+# are stable w.r.t code being re-ordered.
+#
+# In particular, we sort first by the warning description and then by the
+# filename path without its line number element.
+#
+# This assumes all lines are "Warning:" or "Error:" and that file names do not
+# have whitespace.
+function merge_and_sort() {
+  awk '{ if ($0 ~ /:$/) { ORS="" } else { ORS="\n" }; print }' | \
+    sort -s -k 3 | sort -s -t ':' -k 2,2
+}
+
+# Strip out line number information from warnings and errors
+function strip_line_numbers() {
+  sed -e 's@^\(\([Ww]arning\|[Ee]rror\):\s*[/a-zA-Z0-9_.-]*.[ch]\):[0-9]*@\1@' "${@}"
+}
+
+# Diff output, printing a sed range expression for any removed lines.
+function old_lines_to_range() {
+  diff --line-format="" --old-group-format="%df,%dlp;" "${@}"
+}
+
+# Diff output, printing a sed range expression for any newly added lines.
+function new_lines_to_range() {
+  diff --line-format="" --new-group-format="%dF,%dLp;" "${@}"
+}
+
 tmpfile_o=$(mktemp)
 tmpfile_n=$(mktemp)
+tmpfile_so=$(mktemp)
+tmpfile_sn=$(mktemp)
+tmpfile_rm=$(mktemp)
+tmpfile_new=$(mktemp)
 rc=0
 
 files_mod=$(git show --diff-filter=M  --pretty="" --name-only "HEAD")
@@ -15,38 +48,58 @@ HEAD=$(git rev-parse HEAD)
 
 echo "Checking the tree before the patch"
 git checkout -q HEAD~
-./scripts/kernel-doc -Wall -none $files_mod 2> >(tee $tmpfile_o >&2)
+
+echo "Before patch:" >&2
+./scripts/kernel-doc -Wall -none $files_mod 2>&1 | merge_and_sort | tee $tmpfile_o >&2
+
+strip_line_numbers $tmpfile_o > $tmpfile_so
 
 incumbent=$(grep -v 'Error: Cannot open file ' $tmpfile_o | wc -l)
 
 echo "Checking the tree with the patch"
 
 git checkout -q $HEAD
-./scripts/kernel-doc -Wall -none $files_all 2> >(tee $tmpfile_n >&2)
+
+echo "After patch:" >&2
+./scripts/kernel-doc -Wall -none $files_all 2>&1 | merge_and_sort | tee $tmpfile_n >&2
+
+strip_line_numbers $tmpfile_n > $tmpfile_sn
 
 current=$(grep -v 'Error: Cannot open file ' $tmpfile_n | wc -l)
 
-echo "Errors and warnings before: $incumbent this patch: $current" >&$DESC_FD
+# Find removed warnings
+removed_range=$(old_lines_to_range ${tmpfile_so} ${tmpfile_sn})
+sed -n -e "${removed_range}" ${tmpfile_o} > ${tmpfile_rm}
 
-if [ $current -gt $incumbent ]; then
-  echo "New warnings added" 1>&2
-  diff $tmpfile_o $tmpfile_n 1>&2
+removed=$(grep -v 'Error: Cannot open file ' $tmpfile_rm | wc -l)
 
-  echo "Per-file breakdown" 1>&2
-  tmpfile_fo=$(mktemp)
-  tmpfile_fn=$(mktemp)
+# Find new warnings
+new_range=$(new_lines_to_range ${tmpfile_so} ${tmpfile_sn})
+sed -n -e "${new_range}" ${tmpfile_n} > ${tmpfile_new}
 
-  grep -i "\(warn\|error\)" $tmpfile_o | sed -n 's@\(^[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
-    > $tmpfile_fo
-  grep -i "\(warn\|error\)" $tmpfile_n | sed -n 's@\(^[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
-    > $tmpfile_fn
+new_warnings=$(grep -v 'Error: Cannot open file ' $tmpfile_new | wc -l)
 
-  diff $tmpfile_fo $tmpfile_fn 1>&2
-  rm $tmpfile_fo $tmpfile_fn
+echo "Errors and warnings before: $incumbent This patch: $current" >&$DESC_FD
+echo "New: $new_warnings Removed: $removed" >&$DESC_FD
+
+if [ $removed -gt 0 ]; then
+  echo "Warnings removed:" 1>&2
+  sort -V $tmpfile_rm 1>&2
+
+  echo "Per-file breakdown:" 1>&2
+  grep -i "\(warn\|error\)" $tmpfile_rm | sed -n 's@^\([Ww]arning\|[Ee]rror\):\s*\([/a-zA-Z0-9_.-]*.[ch]\):.*@\2@p' | sort | uniq -c 1>&2
+fi
+
+if [ $new_warnings -gt 0 ]; then
+  echo "New warnings added:" 1>&2
+  sort -V $tmpfile_new 1>&2
+
+  echo "Per-file breakdown:" 1>&2
+  grep -i "\(warn\|error\)" $tmpfile_new | sed -n 's@^\([Ww]arning\|[Ee]rror\):\s*\([/a-zA-Z0-9_.-]*.[ch]\):.*@\2@p' | sort | uniq -c 1>&2
 
   rc=1
 fi
 
-rm $tmpfile_o $tmpfile_n
+rm $tmpfile_o $tmpfile_n $tmpfile_so $tmpfile_sn
 
 exit $rc


### PR DESCRIPTION
I had to look at the kdoc test output for some patches recently and found
it to be essentially unusable for quickly resolving the warning. Its output
is a diff (not even unified context) format which includes every warning
that merely changed its line number. This results in a lot of messes, as
most warnings will have line numbers change when code is added, removed, or
rearranged.

In addition, the test can sometimes pass even when it should fail. In rare
cases where a patch remove more warnings that it adds, the end result will
be considered acceptable.

Rather than using the raw diff output, I think we can do much better. I
came up with the idea of using two files in parallel: the original file,
and one with line numbers removed. Diff the two stripped files to figure
out which lines changed, then use sed to extract the changed lines from the
original file.

To ensure the diff won't produce results if line numbers change, we sort
the output of kernel-doc first by the warning text, and then by the file
name without the line number. In addition, warnings of the form "... line:"
which reference a following source line are squashed to a single line.

The diff can then easily pick up which warnings are actually new. It also
allows the kdoc script to log how many warnings are removed (i.e. fixed) as
an added bonus.

One critical change that took a while to track down is that we need to use
regular pipes for the merge and sort, otherwise the sub-process might not
be finished before the next steps of the algorithm continue.

I'm also considering scrapping this diff-based approach and writing a
simple python program that takes the kernel-doc output and does its own
comparison instead of trying to implement this in shell. Suggestions
welcome for any other improvements.

Here's an example of the original output compared to the new output:

```
New warnings added
1c1
< Warning: drivers/net/ethernet/intel/ice/virt/rss.c:160 missing initial short description on line:
---
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:416 missing initial short description on line:
3,5c3,7
< Warning: drivers/net/ethernet/intel/ice/virt/rss.c:269 No description found for return value of 'ice_vc_parse_rss_cfg'
< Warning: drivers/net/ethernet/intel/ice/virt/rss.c:334 No description found for return value of 'ice_vf_adv_rss_offload_ena'
< Warning: drivers/net/ethernet/intel/ice/virt/rss.c:339 missing initial short description on line:
---
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:525 No description found for return value of 'ice_vc_parse_rss_cfg'
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:685 No description found for return value of 'ice_vf_adv_rss_offload_ena'
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:802 No description found for return value of 'ice_hash_remove'
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:1024 No description found for return value of 'ice_map_ip_ctx_idx'
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:1555 missing initial short description on line:
7,8c9,10
< Warning: drivers/net/ethernet/intel/ice/virt/rss.c:347 No description found for return value of 'ice_vc_handle_rss_cfg'
< Warning: drivers/net/ethernet/intel/ice/virt/rss.c:476 missing initial short description on line:
---
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:1563 No description found for return value of 'ice_vc_handle_rss_cfg'
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:1673 missing initial short description on line:
10,11c12,13
< Warning: drivers/net/ethernet/intel/ice/virt/rss.c:483 No description found for return value of 'ice_vc_config_rss_key'
< Warning: drivers/net/ethernet/intel/ice/virt/rss.c:523 missing initial short description on line:
---
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:1680 No description found for return value of 'ice_vc_config_rss_key'
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:1720 missing initial short description on line:
13,14c15,16
< Warning: drivers/net/ethernet/intel/ice/virt/rss.c:530 No description found for return value of 'ice_vc_config_rss_lut'
< Warning: drivers/net/ethernet/intel/ice/virt/rss.c:569 missing initial short description on line:
---
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:1727 No description found for return value of 'ice_vc_config_rss_lut'
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:1766 missing initial short description on line:
16,19c18,21
< Warning: drivers/net/ethernet/intel/ice/virt/rss.c:576 No description found for return value of 'ice_vc_config_rss_hfunc'
< Warning: drivers/net/ethernet/intel/ice/virt/rss.c:618 No description found for return value of 'ice_vc_get_rss_hashcfg'
< Warning: drivers/net/ethernet/intel/ice/virt/rss.c:657 No description found for return value of 'ice_vc_set_rss_hashcfg'
< Warning: include/linux/avf/virtchnl.h:1651 missing initial short description on line:
---
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:1773 No description found for return value of 'ice_vc_config_rss_hfunc'
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:1815 No description found for return value of 'ice_vc_get_rss_hashcfg'
> Warning: drivers/net/ethernet/intel/ice/virt/rss.c:1854 No description found for return value of 'ice_vc_set_rss_hashcfg'
> Warning: include/linux/avf/virtchnl.h:1701 missing initial short description on line:
21c23
< Warning: include/linux/avf/virtchnl.h:1662 No description found for return value of 'virtchnl_vc_validate_vf_msg'
---
> Warning: include/linux/avf/virtchnl.h:1712 No description found for return value of 'virtchnl_vc_validate_vf_msg'
Per-file breakdown
```

Vs...

```
New warnings added:
Warning: drivers/net/ethernet/intel/ice/virt/rss.c:802 No description found for return value of 'ice_hash_remove'
Warning: drivers/net/ethernet/intel/ice/virt/rss.c:1024 No description found for return value of 'ice_map_ip_ctx_idx'
Per-file breakdown:
      2 drivers/net/ethernet/intel/ice/virt/rss.c
```

The context description is also improved to include the new/removed count:

```
Errors and warnings before: 15 This patch: 17 New: 2 Removed: 0
```