### PR TITLE
tests: check_selftest: fix error wording

### DIFF
--- a/tests/patch/check_selftest/validate_config_format.py
+++ b/tests/patch/check_selftest/validate_config_format.py
@@ -11,14 +11,14 @@ def extract_key(raw):
     return k
 
 
-def check_one(a, b, line):
-    _a = extract_key(a)
-    _b = extract_key(b)
+def check_one(current, prev, line):
+    _current = extract_key(current)
+    _prev = extract_key(prev)
 
-    if _a >= _b:
+    if _current >= _prev:
         return None
 
-    return f"Lines {line}-{line+1} invalid order, {a} should be after {b}"
+    return f"Lines {line}-{line+1} invalid order, {current} should be before {prev}"
 
 
 def validate_config(file_path):


### PR DESCRIPTION
while testing check_selftest on my patch, which contains the following order:

	CONFIG_NET_SCH_INGRESS=y
	CONFIG_NETCONSOLE=m

It printed the following error, which is clearly wrong:

	Validation errors in tools/testing/selftests/drivers/net/bonding/config:
	Lines 14-15 invalid order, CONFIG_NETCONSOLE=m should be after CONFIG_NET_SCH_INGRESS=y

Fix the wording saying that current line should come before the previous one, given there is an error and current line is already after previous line. Also rename variables to make the code easier to reason about.


Fixes: af02b9f6 ("tests: make check_selftests check format of Makefiles and configs")