### PR TITLE
air: do not hard-code PW project link name

### DIFF
--- a/pw/patchwork.py
+++ b/pw/patchwork.py
@@ -55,6 +55,10 @@ class Patchwork(object):
                 self._project = int(config_project)
             except ValueError:
                 raise Exception("Patchwork project not found", config_project)
+            pw_project = self.get('projects', self._project)
+            if not pw_project:
+                raise Exception("Patchwork project not found", config_project)
+        self.project_link_name = pw_project['link_name']
 
     def _request(self, url):
         try:

--- a/pw_air_poller.py
+++ b/pw_air_poller.py
@@ -237,6 +237,7 @@ class PwAirPoller:
             'token': self.air_token,
             'tree': self.air_tree,
             'patchwork_series_id': series_id,
+            'patchwork_project_link_name': self.patchwork.project_link_name,
         }
 
         if self.air_branch:

--- a/ui/ai-review.html
+++ b/ui/ai-review.html
@@ -561,7 +561,8 @@
             // Patchwork series ID
             if (data.patchwork_series_id) {
                 document.getElementById('patchwork-info').style.display = 'block';
-                const pwUrl = `https://patchwork.kernel.org/project/netdevbpf/list/?series=${data.patchwork_series_id}`;
+                const pwProject = data.patchwork_project_link_name || 'netdevbpf';
+                const pwUrl = `https://patchwork.kernel.org/project/${pwProject}/list/?series=${data.patchwork_series_id}`;
                 document.getElementById('review-pw-series').innerHTML = `<a href="${pwUrl}" target="_blank" rel="noopener noreferrer">${data.patchwork_series_id}</a>`;
             }
 

--- a/ui/air.html
+++ b/ui/air.html
@@ -1940,7 +1940,8 @@
 
             // Show patch source information
             if (data.patchwork_series_id) {
-                const pwUrl = `https://patchwork.kernel.org/project/netdevbpf/list/?series=${data.patchwork_series_id}`;
+                const pwProject = data.patchwork_project_link_name || 'netdevbpf';
+                const pwUrl = `https://patchwork.kernel.org/project/${pwProject}/list/?series=${data.patchwork_series_id}`;
                 html += `<p><strong>Patchwork Series:</strong> <a href="${pwUrl}" target="_blank" rel="noopener noreferrer">${data.patchwork_series_id}</a></p>`;
             } else if (data.hash) {
                 html += `<p><strong>Hash/Range:</strong> <code>${data.hash}</code></p>`;
@@ -2035,7 +2036,8 @@
                 // Determine submission type
                 let submissionType = '';
                 if (review.patchwork_series_id) {
-                    const pwUrl = `https://patchwork.kernel.org/project/netdevbpf/list/?series=${review.patchwork_series_id}`;
+                    const pwProject = data.patchwork_project_link_name || 'netdevbpf';
+                    const pwUrl = `https://patchwork.kernel.org/project/${pwProject}/list/?series=${review.patchwork_series_id}`;
                     submissionType = `Patchwork: <span onclick="event.stopPropagation(); event.preventDefault(); window.open('${pwUrl}', '_blank');" style="cursor: pointer; text-decoration: underline;">${review.patchwork_series_id}</span>`;
                 } else if (review.hash) {
                     submissionType = `Hash: ${review.hash.substring(0, 12)}`;


### PR DESCRIPTION
Instances using `pw_air_poller.py` are not tracking 'Netdev + BPF' PW project like `air-submit.py` does (if I understood correctly). It is then required to save the project link name in the DB to be able to set links to the right PW project in the UI side.

To be able to achieve that, the Patchwork class needs to remember the project link name that is present in the project info from PW, based on the project full name or ID given in the config. Then, this link name can be attached to the submission, and used in the UI if available.

This should then fix the PW URLs on the reports linked to other PW instances like the MPTCP one, e.g. [here](https://netdev-ai.bots.linux.dev/ai-review.html?id=4692f48a-d9ab-4f51-8f12-923c6a2c475c).

> [!WARNING]
> I was not able to test this, and I don't have access to the config files, so I hope the modifications are correct :)