### PR TITLE
poller: support different tree name and prefix

### DIFF
--- a/netdev/tree_match.py
+++ b/netdev/tree_match.py
@@ -11,8 +11,8 @@ from core import log, log_open_sec, log_end_sec
 
 def series_tree_name_direct(conf_trees, series):
     for t in conf_trees:
-        if re.match(r'\[.*{pfx}.*\]'.format(pfx=t), series.subject):
-            return t
+        if re.match(rf'\[.*{t.pfx}.*\]', series.subject):
+            return t.name
 
 
 def _file_name_match_start(pfx, fn):

--- a/pw_poller.py
+++ b/pw_poller.py
@@ -96,7 +96,7 @@ class PwPoller:
             pass
 
     def _series_determine_tree(self, s: PwSeries) -> str:
-        s.tree_name = self.list_module.series_tree_name_direct(self._trees.keys(), s)
+        s.tree_name = self.list_module.series_tree_name_direct(self._trees.values(), s)
         s.tree_mark_expected = True
         s.tree_marked = bool(s.tree_name)
 


### PR DESCRIPTION
The current code was assuming that the tree name and prefix were always the same, but that's not necessary the case.

Instead, pass a list of Trees, so it is possible to access to both the name and prefix.

Note: this modification requires an adaptation of the list module, e.g. for those not using the "netdev" modules.

==> Are there many users of this list module? I guess no, but if yes, I can also modify the code to only pass the prefixes to `series_tree_name_direct()` (instead of the names like before this PR), and then find the tree name associated to such prefix.