### PR TITLE
pw: retry POST actions 3 times instead of 1

### DIFF
--- a/pw/patchwork.py
+++ b/pw/patchwork.py
@@ -226,10 +226,13 @@ class Patchwork(object):
         }
 
         r = self._post(f'patches/{patch}/checks/', headers=headers, data=data)
-        if r.status_code == 502 or r.status_code == 504:
-            # Timeout, let's wait 30 sec and retry, POST isn't retried by the lib.
-            time.sleep(30)
-            r = self._post(f'patches/{patch}/checks/', headers=headers, data=data)
+        for retry in range(3):
+            if r.status_code == 502 or r.status_code == 504:
+                # Timeout, let's wait 30 sec and retry, POST isn't retried by the lib.
+                time.sleep(30 << retry)
+                r = self._post(f'patches/{patch}/checks/', headers=headers, data=data)
+            else:
+                break
         if r.status_code != 201:
             raise PatchworkPostException(r)
 


### PR DESCRIPTION
More errors are visible recently. The last one got two 504 errors in a row.

It seems better to retry 2 times more with an exponential back-off, so retrying for maximum 3 minutes 30 + the timeout period.

Note: this is currently only the POST side. The GET will certainly follow soon when we can get the confirmation that the same error is happening on the GET side (which is very likely...)