### PR TITLE
pw: retry on 502 and 504 errors

### DIFF
--- a/pw/patchwork.py
+++ b/pw/patchwork.py
@@ -31,7 +31,8 @@ class PatchworkPostException(Exception):
 class Patchwork(object):
     def __init__(self, config):
         self._session = requests.Session()
-        retry = Retry(connect=10, backoff_factor=1)
+        retry = Retry(connect=10, status=10, status_forcelist={502, 504},
+                      backoff_factor=1)
         adapter = HTTPAdapter(max_retries=retry)
         self._session.mount('http://', adapter)
         self._session.mount('https://', adapter)


### PR DESCRIPTION
Recently, some services have failed due to a 504 error from Patchwork when retrieving a JSON with:

    self._request(...).json()

or:

    self._get(...).json()

In both cases, the logs were showing:

    **** Response
    <Response [504]>
    **** Response data
    <html>
    <head><title>504 Gateway Time-out</title></head>
    <body>
    <center><h1>504 Gateway Time-out</h1></center>
    </body>
    </html>

Ask the requests lib to retry on 502 and 504 for us, that seems the easiest (if this works as expected).