### PR TITLE
cmd: log: display date along time

### DIFF
--- a/core/cmd.py
+++ b/core/cmd.py
@@ -71,7 +71,7 @@ def cmd_run(cmd: List[str], shell=False, include_stderr=False, add_env=None, cwd
     if add_env:
         env.update(add_env)
 
-    core.log("START", datetime.datetime.now().strftime("%H:%M:%S.%f"))
+    core.log("START", datetime.datetime.now().isoformat())
 
     process = subprocess.Popen(cmd, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                env=env, cwd=cwd, pass_fds=pass_fds)
@@ -91,7 +91,7 @@ def cmd_run(cmd: List[str], shell=False, include_stderr=False, add_env=None, cwd
     core.log("RETCODE", process.returncode)
     core.log("STDOUT", stdout)
     core.log("STDERR", stderr)
-    core.log("END", datetime.datetime.now().strftime("%H:%M:%S.%f"))
+    core.log("END", datetime.datetime.now().isoformat())
     core.log_end_sec()
 
     if process.returncode != 0:


### PR DESCRIPTION
Only displaying the time in a log file covering multiple days is confusing: when a strange pattern is found, it is required to browse around to find for which day it was.

Use the ISO format instead, to display something like:

    2026-07-22T19:39:39.175036

Instead of just:

    19:39:39.175036