### PR TITLE
Patchwork: retry POST/PATCH (longer) with Retry + more log

### DIFF
--- a/pw/patchwork.py
+++ b/pw/patchwork.py
@@ -173,7 +173,10 @@ class Patchwork(object):
             core.log("Headers", headers)
             core.log("Data", data)
             core.log("Response", ret)
-            core.log("Response data", ret.json())
+            try:
+                core.log("Response data", ret.json())
+            except json.decoder.JSONDecodeError:
+                core.log("Response data", ret.content.decode())
         finally:
             core.log_end_sec()
 

--- a/pw/patchwork.py
+++ b/pw/patchwork.py
@@ -168,7 +168,7 @@ class Patchwork(object):
     def _patch(self, req, headers, data, api='1.1'):
         url = f'{self._proto}{self.server}/api/{api}/{req}'
         try:
-            core.log_open_sec(f"Patchwork {self.server} post: {url}")
+            core.log_open_sec(f"Patchwork {self.server} patch: {url}")
             ret = self._session.patch(url, headers=headers, data=data)
             core.log("Headers", headers)
             core.log("Data", data)

--- a/pw/patchwork.py
+++ b/pw/patchwork.py
@@ -72,7 +72,7 @@ class Patchwork(object):
                 core.log("Response data", ret.content.decode())
         finally:
             end = datetime.datetime.now()
-            core.log("Response time (sec)", (end - start).total_seconds())
+            core.log("Response time GET (sec)", (end - start).total_seconds())
             core.log_end_sec()
 
         return ret
@@ -149,8 +149,10 @@ class Patchwork(object):
 
     def _post(self, req, headers, data, api='1.1'):
         url = f'{self._proto}{self.server}/api/{api}/{req}'
+        core.log_open_sec(f"Patchwork {self.server} post: {url}")
+        start = datetime.datetime.now()
+
         try:
-            core.log_open_sec(f"Patchwork {self.server} post: {url}")
             ret = self._session.post(url, headers=headers, data=data)
             core.log("Headers", headers)
             core.log("Data", data)
@@ -160,6 +162,8 @@ class Patchwork(object):
             except json.decoder.JSONDecodeError:
                 core.log("Response data", ret.content.decode())
         finally:
+            end = datetime.datetime.now()
+            core.log("Response time POST (sec)", (end - start).total_seconds())
             core.log_end_sec()
 
         return ret
@@ -167,8 +171,10 @@ class Patchwork(object):
     # PATCH as in the HTTP method, not getting a patch
     def _patch(self, req, headers, data, api='1.1'):
         url = f'{self._proto}{self.server}/api/{api}/{req}'
+        core.log_open_sec(f"Patchwork {self.server} patch: {url}")
+        start = datetime.datetime.now()
+
         try:
-            core.log_open_sec(f"Patchwork {self.server} patch: {url}")
             ret = self._session.patch(url, headers=headers, data=data)
             core.log("Headers", headers)
             core.log("Data", data)
@@ -178,6 +184,8 @@ class Patchwork(object):
             except json.decoder.JSONDecodeError:
                 core.log("Response data", ret.content.decode())
         finally:
+            end = datetime.datetime.now()
+            core.log("Response time PATCH (sec)", (end - start).total_seconds())
             core.log_end_sec()
 
         return ret

--- a/pw/patchwork.py
+++ b/pw/patchwork.py
@@ -62,6 +62,7 @@ class Patchwork(object):
     def _request(self, url):
         core.log_open_sec(f"Patchwork {self.server} request: {url}")
         start = datetime.datetime.now()
+        core.log("Start", start)
 
         try:
             ret = self._session.get(url)
@@ -151,6 +152,7 @@ class Patchwork(object):
         url = f'{self._proto}{self.server}/api/{api}/{req}'
         core.log_open_sec(f"Patchwork {self.server} post: {url}")
         start = datetime.datetime.now()
+        core.log("Start", start)
 
         try:
             ret = self._session.post(url, headers=headers, data=data)
@@ -173,6 +175,7 @@ class Patchwork(object):
         url = f'{self._proto}{self.server}/api/{api}/{req}'
         core.log_open_sec(f"Patchwork {self.server} patch: {url}")
         start = datetime.datetime.now()
+        core.log("Start", start)
 
         try:
             ret = self._session.patch(url, headers=headers, data=data)

--- a/pw/patchwork.py
+++ b/pw/patchwork.py
@@ -32,8 +32,9 @@ class PatchworkPostException(Exception):
 class Patchwork(object):
     def __init__(self, config):
         self._session = requests.Session()
+        allowed_methods = Retry.DEFAULT_ALLOWED_METHODS | {'POST', 'PATCH'}
         retry = Retry(connect=10, status=10, status_forcelist={502, 504},
-                      backoff_factor=1)
+                      allowed_methods=allowed_methods, backoff_factor=1)
         adapter = HTTPAdapter(max_retries=retry)
         self._session.mount('http://', adapter)
         self._session.mount('https://', adapter)
@@ -232,13 +233,6 @@ class Patchwork(object):
         }
 
         r = self._post(f'patches/{patch}/checks/', headers=headers, data=data)
-        for retry in range(3):
-            if r.status_code == 502 or r.status_code == 504:
-                # Timeout, let's wait 30 sec and retry, POST isn't retried by the lib.
-                time.sleep(30 << retry)
-                r = self._post(f'patches/{patch}/checks/', headers=headers, data=data)
-            else:
-                break
         if r.status_code != 201:
             raise PatchworkPostException(r)
 


### PR DESCRIPTION
Recently, the nipa-upload-wireless service failed because it wasn't able to POST a PW check, even after 3 retries. All attempts failed with a 504 error. With the previous code, it was retrying only during 3.5 minutes, compared to ~17 minutes with the lib. Switching to the lib: it should be better, also for maintenance purposes. That also leaves more time for PW server maintenance operations.

While at it, improve the log: typo, non-JSON data, response time, and timestamps.

That's not urgent.