### PR TITLE
fetchers: add marker at the end of the test

### DIFF
--- a/contest/hw/hwksft.py
+++ b/contest/hw/hwksft.py
@@ -369,6 +369,7 @@ def test(binfo, rinfo, cbarg):  # pylint: disable=unused-argument
         except Exception as e:
             print(f"Warning: failed to close reservation {reservation_id}: {e}")
 
+    os.mknod(os.path.join(results_path, ".tester_done"))
     print("Done at", datetime.datetime.now())
     if cases is None:
         cases = [{

--- a/contest/remote/exec.py
+++ b/contest/remote/exec.py
@@ -76,6 +76,9 @@ def test(binfo, rinfo, config):
            config.get('local', 'results_path') + '/' + \
            rinfo['run-cookie']
 
+    os.mknod(os.path.join(results_path, ".tester_done"))
+    print("Done at", datetime.datetime.now())
+
     return [{'test': config.get('executor', 'test'),
              'group': config.get('executor', 'group'),
              'result': res, 'link': link}]

--- a/contest/remote/gh.py
+++ b/contest/remote/gh.py
@@ -219,6 +219,9 @@ def test(binfo, rinfo, cbarg):
                 one['retry'] = one2['result']
                 break
 
+    os.mknod(os.path.join(results_path, ".tester_done"))
+    print("Done at", datetime.datetime.now())
+
     return res
 
 

--- a/contest/remote/kunit.py
+++ b/contest/remote/kunit.py
@@ -194,6 +194,7 @@ def test(binfo, rinfo, config):
                   'group': config.get('executor', 'group'),
                   'result': 'fail', 'link': link}]
 
+    os.mknod(os.path.join(results_path, ".tester_done"))
     print("Done at", datetime.datetime.now())
 
     return cases

--- a/contest/remote/vmksft-p.py
+++ b/contest/remote/vmksft-p.py
@@ -317,6 +317,7 @@ def test(binfo, rinfo, cbarg):
     if not in_queue.empty():
         print("ERROR: in queue is not empty")
 
+    os.mknod(os.path.join(results_path, ".tester_done"))
     print("Done at", datetime.datetime.now())
 
     return cases

--- a/contest/remote/vmksft.py
+++ b/contest/remote/vmksft.py
@@ -221,6 +221,7 @@ def test(binfo, rinfo, cbarg):
     vm.stop()
     vm.dump_log(results_path + '/vm-stop')
 
+    os.mknod(os.path.join(results_path, ".tester_done"))
     print("Done at", datetime.datetime.now())
 
     return cases

--- a/contest/remote/vmtest.py
+++ b/contest/remote/vmtest.py
@@ -129,6 +129,7 @@ def test(binfo, rinfo, cbarg):
     vm.stop()
     vm.dump_log(results_path + '/vm-stop-' + str(vm_id))
 
+    os.mknod(os.path.join(results_path, ".tester_done"))
     print("Done at", datetime.datetime.now())
 
     return cases


### PR DESCRIPTION
This imitates what is done by the poller node: when this marker is written, the uploader service knows it can stop monitoring the current directory. This avoids having too many inotify instances which can cause troubles.

All users of "Fetcher" are using the same pattern: a log message and the creation of the result dir at the beginning, and a log message at the end (except for `exec` and `gh`, added here). Now, an empty `.tester_done` file is created at the end as well.

Note that some of these fetchers don't seem to be used any more.