### PR TITLE
contest: retry when unable to load input files

### DIFF
--- a/contest/results-faker.py
+++ b/contest/results-faker.py
@@ -33,8 +33,12 @@ def combine_infos(config):
         with open(path, "r") as fp:
             infos.update(json.load(fp))
 
-    with open(config.get("output", "info"), 'w') as fp:
+    # atomic write needed
+    path = config.get("output", "info")
+    tmp = path + '.new'
+    with open(tmp, 'w') as fp:
         json.dump(infos, fp)
+    os.rename(tmp, path)
 
 
 def main() -> None:


### PR DESCRIPTION
The contest service was unable to load the 'branch_info' input file twice yesterday. Probably because it was being updated:

    json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

Catch the error, and retry max 4 more times with the same delay.