### PR TITLE
gh: lint: restrict to main branch and python files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,18 @@
 # Run linters on code in repo to avoid common issues:
 # * YAPF for Python scripts
 name: Lint checks
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '**.py'
+  pull_request:
+    paths:
+      - '**.py'
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - uses: cclauss/Find-Python-syntax-errors-action@master


### PR DESCRIPTION
Not to execute that for each push, and when it is not needed.

While at it, also bump the checkout version to switch to latest node version and avoid the deprecation warning.