### PR TITLE
gh: docker: use the `docker` driver

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -29,6 +29,8 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker
       -
         name: Login to GHCR
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
Instead of `docker-container` which will fail when trying to get remote metadata for non already built images, e.g.

```
#2 [internal] load metadata for ghcr.io/linux-netdev/nipa-base:latest
#2 ERROR: failed to authorize: failed to fetch anonymous token: unexpected status from GET request to https://ghcr.io/token?scope=repository%3Alinux-netdev%2Fnipa-base%3Apull&service=ghcr.io: 403 Forbidden
```

From [here](https://github.com/linux-netdev/nipa/actions/runs/32765245383/job/97553122727#step:6:1178)

Thanks to this modification, it is possible to build images for non already published images, e.g. when testing modifications in another repo.