### PR TITLE
pw: retry on 404 errors

### DIFF
--- a/pw/patchwork.py
+++ b/pw/patchwork.py
@@ -74,7 +74,7 @@ class Patchwork(object):
         self._session = requests.Session()
         allowed_methods = Retry.DEFAULT_ALLOWED_METHODS | {'POST', 'PATCH'}
         retry = Retry(connect=10, status=10,
-                      status_forcelist={429, 502, 503, 504},
+                      status_forcelist={404, 429, 502, 503, 504},
                       allowed_methods=allowed_methods, backoff_factor=1)
         adapter = HTTPAdapter(max_retries=retry)
         self._session.mount('http://', adapter)


### PR DESCRIPTION
This is a temp fix while Lore is being used to retrieve patches.

Because PW and Lore are two async services now used to get info about patches, it is possible one is updated after the other. This is problematic if Lore is updated after, and this already happened:

  pw.patchwork.PatchworkFetchException: ('https://lore.kernel.org/all/20260908132926.68976-6-luka.gejak%40linux.dev/raw', <Response [404]>)

The URL is now valid, but it wasn't at that time.

Retrying is the solution, but it feels like when PW is fixed, it would be better to use it to download patches as well instead of relying on different services that can have different issues.

An alternative is to use two different sessions, but if all of this is linked to a temp workaround, no need to bother.