### PR TITLE
docker: base: add pigz

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -5,7 +5,7 @@ LABEL name=nipa-base
 
 RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
 RUN dnf install -y \
-		bison ccache flex gcc make rsync \
+		bison ccache flex gcc make pigz rsync \
 		bc cpio curl diffutils gawk git perl openssl patch which \
 		elfutils-libelf-devel ncurses-devel openssl-devel && \
 	sudo dnf clean all


### PR DESCRIPTION
It can be already used by passing KGZIP=pigz to 'make' commands to accelerate some steps.

In a near future, it might be used by default [1].

Link: https://lore.kernel.org/20260908-build-speedup-v1-23-5dc1ac01672d@kernel.org [1]