### PR TITLE
status: get a trimmed checks.json file

### DIFF
--- a/check_fetcher.py
+++ b/check_fetcher.py
@@ -39,6 +39,7 @@ def main():
 
     rdir = config.get('dirs', 'results', fallback=os.path.join(NIPA_DIR, "results"))
     tgt_json = os.path.join(rdir, "checks.json")
+    tgt_json_status = os.path.join(rdir, "checks-status.json")
 
     # Time bounds
     retain_history_days = 60         # how much data we want in the JSON
@@ -55,6 +56,7 @@ def main():
 
     json_resp = pw.get_patches_all(delegate=delegate, since=since)
     jdb = []
+    jdb_status = []
     old_unchanged = 0
     check_updates = 0
     seen_pids = set()
@@ -89,6 +91,17 @@ def main():
                 "check-date": c["date"]
             }
             jdb.append(info)
+
+            info = {
+                "date": p["date"],
+                "check": c["context"],
+                "check-date": c["date"]
+            }
+            jdb_status.append(info)
+
+    # only the "recent" ones
+    with open(tgt_json_status, "w") as fp:
+        json.dump(jdb_status, fp)
 
     new_db = []
     skipped = 0

--- a/scripts/ui_assets.sh
+++ b/scripts/ui_assets.sh
@@ -16,6 +16,7 @@ PROD=https://netdev.bots.linux.dev
 LOCAL=./ui
 ASSETS=(
   "checks.json"
+  "checks-status.json"
   "status.json"
   "issues.json"
   "contest/branch-results.json"

--- a/ui/status.js
+++ b/ui/status.js
@@ -1261,7 +1261,7 @@ function do_it()
      * Please remember to keep these assets in sync with `scripts/ui_assets.sh`
      */
     $(document).ready(function() {
-        $.get("checks.json", run_it)
+        $.get("checks-status.json", run_it)
     });
     $(document).ready(function() {
         $.get("status.json", status_system)


### PR DESCRIPTION
This file is currently over 50M, containing a lot of unused data: for status.html, we don't need data older than 7 days, nor a lot of fields from it.

Create a special version for it, and load it in status.js instead.