### PR TITLE
tests: series: diff: filter out empty diff

### DIFF
--- a/tests/series/diff/diff.sh
+++ b/tests/series/diff/diff.sh
@@ -13,7 +13,7 @@ OUT="${RESULTS_DIR}/b4-diff.ansi"
 # ignore errors, we just want to see the diff if available
 b4 diff --color --output-diff "${OUT}" "${MSGID}" || true
 
-if [ -s "${OUT}" ]; then
+if grep -q "^    " "${OUT}" 2>/dev/null; then
   echo "Diff with the previous version in $(basename "${OUT}")" >&"${DESC_FD}"
 else
   echo "No diff available" >&"${DESC_FD}"


### PR DESCRIPTION
In some cases, git range-diff might say the patches are too different, and just list the files. No need to check such files.

Check that the output file, if any, contains a couple of spaces at the beginning of the line.